### PR TITLE
docs: Update .example.env with TiDB and new AI vars

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,7 +1,19 @@
-# API Keys
-OPENROUTER_API_KEY=your_openrouter_api_key
-OPENROUTER_REFERER=http://localhost:3000
-OPENROUTER_TITLE=Askable (Local)
+# AI Provider (OpenRouter)
+OPENROUTER_API_KEY="your_openrouter_api_key"
+OPENROUTER_REFERRER="http://localhost:3000" # Recommended by OpenRouter
+OPENROUTER_APP_NAME="Askable (Local)" # Recommended by OpenRouter, appears as "X-Title" header
+OPENROUTER_MODEL="anthropic/claude-3.5-sonnet" # Optional, model to use
+OPENROUTER_BASE_URL="https://openrouter.ai/api/v1" # Optional, if using a different endpoint
+
+# Database (TiDB Serverless via mysql2 driver)
+TIDB_HOST="your_tidb_host"
+TIDB_PORT="4000"
+TIDB_USER="your_tidb_user"
+TIDB_PASSWORD="your_tidb_password"
+TIDB_DATABASE="your_tidb_database"
+TIDB_ENABLE_SSL="true"
+TIDB_TLS_REJECT_UNAUTHORIZED="true" # Set to 'false' to bypass cert verification (not recommended for production)
+TIDB_SSL_CA="" # Optional, path to or content of CA certificate (PEM format)
 
 # (Optional) Helicone or other observability proxies
 HELICONE_API_KEY=
@@ -12,6 +24,10 @@ S3_UPLOAD_SECRET=
 S3_UPLOAD_BUCKET=
 S3_UPLOAD_REGION=
 
-# Upstash Redis
-UPSTASH_REDIS_REST_URL=
-UPSTASH_REDIS_REST_TOKEN=
+# Logging
+LOG_LEVEL="info" # 'debug', 'info', 'warn', 'error', 'fatal'
+
+# AI Debugging
+DEBUG_AI="false" # Set to 'true' to force non-streaming responses with full error details from the AI provider
+FORCE_NON_STREAM="false" # Alternative to DEBUG_AI
+LOG_TOKENS="false" # Set to 'true' for verbose token-level logging


### PR DESCRIPTION
This commit updates the `.example.env` file to reflect the new environment variable requirements for the application after migrating from Redis to TiDB and adding a more robust OpenRouter integration.

- Removed `UPSTASH_REDIS_` variables.
- Added `TIDB_` variables for the database connection.
- Added new optional and debugging variables for the OpenRouter and AI SDK integration (`OPENROUTER_MODEL`, `DEBUG_AI`, etc.).
- Added `LOG_LEVEL` for the new structured logger.