### PR TITLE
Fix: Persist CSV file context across chat messages

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -9,7 +9,7 @@ import { limitMessages } from "@/lib/limits";
 import { generateCodePrompt } from "@/lib/prompts";
 import { CHAT_MODELS } from "@/lib/models";
 export async function POST(req: Request) {
-  const { id, message, model } = await req.json();
+  const { id, message, model, chatData } = await req.json();
 
   const errorResolved = req.headers.get("X-Auto-Error-Resolved");
 
@@ -34,7 +34,7 @@ export async function POST(req: Request) {
     isAutoErrorResolution: errorResolved === "true",
   };
 
-  await saveNewMessage({ id, message: newUserMessage });
+  await saveNewMessage({ id, message: newUserMessage, chatData });
 
   const messagesToSave: DbMessage[] = [
     ...(chat?.messages || []),
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
           duration,
           model: selectedModel,
         };
-        await saveNewMessage({ id, message: assistantMessage });
+        await saveNewMessage({ id, message: assistantMessage, chatData });
       },
     });
 

--- a/src/components/chat-screen.tsx
+++ b/src/components/chat-screen.tsx
@@ -70,6 +70,11 @@ export function ChatScreen({
         message: messages[messages.length - 1].content,
         id,
         model: selectedModelSlug,
+        chatData: {
+          csvFileUrl: uploadedFile?.url,
+          csvHeaders: uploadedFile?.csvHeaders,
+          csvRows: uploadedFile?.csvRows,
+        },
       };
     },
     // Fake tool call

--- a/src/lib/chat-store.ts
+++ b/src/lib/chat-store.ts
@@ -72,9 +72,11 @@ export async function loadChat(id: string): Promise<ChatData | null> {
 export async function saveNewMessage({
   id,
   message,
+  chatData,
 }: {
   id: string;
   message: DbMessage;
+  chatData?: Partial<ChatData>;
 }): Promise<void> {
   const chat = await loadChat(id);
   if (chat) {
@@ -90,9 +92,9 @@ export async function saveNewMessage({
     // If chat does not exist, create a new one with this message
     const newChat: ChatData = {
       messages: [message],
-      csvHeaders: null,
-      csvRows: null,
-      csvFileUrl: null,
+      csvHeaders: chatData?.csvHeaders || null,
+      csvRows: chatData?.csvRows || null,
+      csvFileUrl: chatData?.csvFileUrl || null,
       title: null,
     };
     await runQuery("INSERT INTO chats (id, data) VALUES (?, ?)", [


### PR DESCRIPTION
This commit fixes a bug where the application would forget that a CSV file had been uploaded after the first message was sent. This was caused by a race condition with the distributed database, where the initial chat record was being overwritten by a subsequent message save that did not have the file context.

The fix involves passing the file's metadata (`csvFileUrl`, `csvHeaders`, `csvRows`) with every chat message request from the frontend to the backend. The `saveNewMessage` function in the data store has been updated to use this data to correctly create a new chat record if one is not found, thus preventing the file context from being lost.