### PR TITLE
fix(upload): Relax CSV MIME type validation and improve feedback

### DIFF
--- a/src/components/UploadCsvDialog.tsx
+++ b/src/components/UploadCsvDialog.tsx
@@ -32,16 +32,23 @@ export function UploadCsvDialog({ open, onOpenChange, onFileSelected, loading = 
       toast.warning("Please select a CSV file");
       return;
     }
-    if (file.type !== "text/csv") {
+
+    // Accept common CSV MIME types and also fall back to .csv extension check
+    const allowedMimeTypes = ["text/csv", "application/vnd.ms-excel", "text/plain", ""];
+    const isCsv = allowedMimeTypes.includes(file.type) || file.name.toLowerCase().endsWith(".csv");
+
+    if (!isCsv) {
       toast.warning("Only .csv files are supported");
       return;
     }
+
     if (file.size > 30 * 1024 * 1024) {
       toast.warning("File size must be less than 30MB");
       return;
     }
-  onFileSelected(file);
-  }, [onFileSelected, onOpenChange]);
+
+    onFileSelected(file);
+  }, [onFileSelected]);
 
   const onUseExample = useCallback(async () => {
     try {

--- a/src/components/upload-area.tsx
+++ b/src/components/upload-area.tsx
@@ -31,13 +31,24 @@ export function UploadArea({ onFileChange, uploadedFile }: UploadAreaProps) {
         <Dropzone
           multiple={false}
           accept={{
-            // accept csv
             "text/csv": [".csv"],
+            "application/vnd.ms-excel": [".csv"],
+            "text/plain": [".csv"],
           }}
           onDrop={(acceptedFiles) => {
             const file = acceptedFiles[0];
-
             if (!file) {
+              toast.warning("Please upload a CSV file");
+              return;
+            }
+            // fallback: check extension too
+            if (
+              !(
+                file.type === "text/csv" ||
+                file.type === "application/vnd.ms-excel" ||
+                file.name.toLowerCase().endsWith(".csv")
+              )
+            ) {
               toast.warning("Please upload a CSV file");
               return;
             }


### PR DESCRIPTION
This commit addresses an issue where CSV uploads could fail silently due to strict MIME type checking or unclear error reporting.

The changes include:
- Relaxing the CSV file validation in `UploadCsvDialog.tsx` and `upload-area.tsx` to accept common MIME types (`text/csv`, `application/vnd.ms-excel`, `text/plain`) and falling back to a file extension check (`.csv`).
- Enhancing the `handleFileUpload` function in `page.tsx` to provide clear success and error toasts, ensuring the user is informed about the status of their upload.
- Adding a check to ensure a valid URL is returned from the S3 upload, preventing states where the upload appears to succeed but no URL is available.