### PR TITLE
Fix: Conditionally set ssl.ca in database client

### DIFF
--- a/src/lib/clients.ts
+++ b/src/lib/clients.ts
@@ -31,8 +31,10 @@ function getConfig() {
     ssl = {
       minVersion: 'TLSv1.2',
       rejectUnauthorized: TIDB_TLS_REJECT_UNAUTHORIZED === 'true',
-      ca: TIDB_SSL_CA,
     };
+    if (TIDB_SSL_CA) {
+      ssl.ca = TIDB_SSL_CA;
+    }
   }
 
   return {


### PR DESCRIPTION
The `getConfig` function in `src/lib/clients.ts` was unconditionally assigning the `TIDB_SSL_CA` environment variable to the `ca` property of the SSL configuration. When running in an environment where `TIDB_SSL_CA` is not set (e.g., an empty string), this could cause the `mysql2` database driver to fail during SSL certificate validation, leading to an "Internal Server Error" on any API route that uses the database.

This commit modifies the logic to only set the `ssl.ca` property if the `TIDB_SSL_CA` environment variable has a truthy value. This makes the database connection more robust and prevents crashes when the optional CA variable is not provided.